### PR TITLE
SiteLibrary: Lazy-load site stats table

### DIFF
--- a/includes/Engines/LuaCommon/SiteLibrary.php
+++ b/includes/Engines/LuaCommon/SiteLibrary.php
@@ -27,6 +27,7 @@ class SiteLibrary extends LibraryBase {
 			'pagesInNamespace' => [ $this, 'pagesInNamespace' ],
 			'usersInGroup' => [ $this, 'usersInGroup' ],
 			'interwikiMap' => [ $this, 'interwikiMap' ],
+			'loadStats' => [ $this, 'loadStats' ],
 		];
 		$parser = $this->getParser();
 		$services = MediaWikiServices::getInstance();
@@ -93,8 +94,16 @@ class SiteLibrary extends LibraryBase {
 		}
 		$info['namespaces'] = self::$namespacesCache;
 
+		return $this->getEngine()->registerInterface( 'mw.site.lua', $lib, $info );
+	}
+
+	/**
+	 * Lazy-loads the site stats table.
+	 * @return int[][]
+	 */
+	public function loadStats() {
 		if ( defined( 'MW_PHPUNIT_TEST' ) ) {
-			$info['stats'] = [
+			return [ [
 				'pages' => 1,
 				'articles' => 1,
 				'files' => 0,
@@ -102,20 +111,18 @@ class SiteLibrary extends LibraryBase {
 				'users' => 1,
 				'activeUsers' => 1,
 				'admins' => 1,
-			];
-		} else {
-			$info['stats'] = [
-				'pages' => (int)SiteStats::pages(),
-				'articles' => (int)SiteStats::articles(),
-				'files' => (int)SiteStats::images(),
-				'edits' => (int)SiteStats::edits(),
-				'users' => (int)SiteStats::users(),
-				'activeUsers' => (int)SiteStats::activeUsers(),
-				'admins' => (int)SiteStats::numberingroup( 'sysop' ),
-			];
+			] ];
 		}
 
-		return $this->getEngine()->registerInterface( 'mw.site.lua', $lib, $info );
+		return [ [
+			'pages' => (int)SiteStats::pages(),
+			'articles' => (int)SiteStats::articles(),
+			'files' => (int)SiteStats::images(),
+			'edits' => (int)SiteStats::edits(),
+			'users' => (int)SiteStats::users(),
+			'activeUsers' => (int)SiteStats::activeUsers(),
+			'admins' => (int)SiteStats::numberingroup( 'sysop' ),
+		] ];
 	}
 
 	/**

--- a/includes/Engines/LuaCommon/lualib/mw.site.lua
+++ b/includes/Engines/LuaCommon/lualib/mw.site.lua
@@ -11,10 +11,6 @@ function site.setupInterface( info )
 	site.scriptPath = info.scriptPath
 	site.stylePath = info.stylePath
 	site.currentVersion = info.currentVersion
-	site.stats = info.stats
-	site.stats.pagesInCategory = php.pagesInCategory
-	site.stats.pagesInNamespace = php.pagesInNamespace
-	site.stats.usersInGroup = php.usersInGroup
 	site.interwikiMap = php.interwikiMap
 
 	-- Process namespace list into more useful tables
@@ -68,6 +64,22 @@ function site.setupInterface( info )
 				end
 			end
 			return rawget( t, k )
+		end
+	} )
+
+	-- Lazy-load the stats table to avoid an unnecessary DB query if it's not used
+	setmetatable( site, {
+		__index = function( t, key )
+			if key == 'stats' then
+				local stats = php.loadStats()
+
+				stats.pagesInCategory = php.pagesInCategory
+				stats.pagesInNamespace = php.pagesInNamespace
+				stats.usersInGroup = php.usersInGroup
+
+				rawset( t, key, stats )
+				return stats
+			end
 		end
 	} )
 


### PR DESCRIPTION
This avoids an extra DB query and object cache lookup if Scribunto is used but mw.site.stats isn't.

Cherry-picked from https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Scribunto/+/1259218

Closes WG-258